### PR TITLE
Left iterator in IOTokenList fixed

### DIFF
--- a/Meat/Lexy.cpp
+++ b/Meat/Lexy.cpp
@@ -322,7 +322,7 @@ bool Lexy::performArithmetic(TokenList& IOTokenList)
 
 		if(curIndex < endIndex)
 		{
-			IOTokenList.erase(leftIter, rightIter+1);
+			leftIter = IOTokenList.erase(leftIter, rightIter+1);
 
 			// std::cout << "Result Token = ";
 


### PR DESCRIPTION
Vector emplace iterator was out of range after erasing from the IOTokenList. The return value used to update the iterator to avoid this